### PR TITLE
Grant new jenkins mi per environment on the KV

### DIFF
--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,0 +1,4 @@
+
+maxfragmentationmemory_reserved = "125"
+maxmemory_delta = "125"
+maxmemory_reserved = "125"

--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,4 +1,3 @@
-
 maxfragmentationmemory_reserved = "125"
 maxmemory_delta                 = "125"
 maxmemory_reserved              = "125"

--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,4 +1,4 @@
 
 maxfragmentationmemory_reserved = "125"
-maxmemory_delta = "125"
-maxmemory_reserved = "125"
+maxmemory_delta                 = "125"
+maxmemory_reserved              = "125"

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -9,4 +9,10 @@ module "tt-key-vault" {
   product_group_name      = var.product_group_name
   common_tags             = var.common_tags
   create_managed_identity = true
+  jenkins_object_id       = data.azurerm_user_assigned_identity.jenkins.principal_id
+}
+
+data "azurerm_user_assigned_identity" "jenkins" {
+  name                = "jenkins-${var.env}-mi"
+  resource_group_name = "managed-identities-${var.env}-rg"
 }

--- a/redis.tf
+++ b/redis.tf
@@ -6,13 +6,16 @@ module "redis" {
   common_tags = var.common_tags
   name        = "${var.product}-cft-${var.env}"
 
-  redis_version                 = "6"
-  business_area                 = "cft"
-  private_endpoint_enabled      = true
-  public_network_access_enabled = false
-  sku_name                      = var.sku_name
-  family                        = var.family
-  capacity                      = var.capacity
+  redis_version                   = "6"
+  business_area                   = "cft"
+  private_endpoint_enabled        = true
+  public_network_access_enabled   = false
+  sku_name                        = var.sku_name
+  family                          = var.family
+  capacity                        = var.capacity
+  maxfragmentationmemory_reserved = var.maxfragmentationmemory_reserved
+  maxmemory_delta                 = var.maxmemory_delta
+  maxmemory_reserved              = var.maxmemory_reserved
 }
 
 # Format: rediss://:[password]@[hostname]:[port]/[db]

--- a/variables-defaults.tf
+++ b/variables-defaults.tf
@@ -89,4 +89,16 @@ variable "capacity" {
   description = "The size of the Redis cache to deploy. Valid values are 1, 2, 3, 4, 5"
 }
 
+variable "maxfragmentationmemory_reserved" {
+  default = "642"
+}
+
+variable "maxmemory_delta" {
+  default = "642"
+}
+
+variable "maxmemory_reserved" {
+  default = "642"
+}
+
 variable "mgmt_subscription_id" {}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-30518

### Change description

We (Platform Operations) are adding an additional Jenkins MIs that are per-environment.
This will ensure that pipeline for this repository does not break once we start enforcing access segmentation within Jenkins
Here is the epic for some context: https://tools.hmcts.net/jira/browse/DTSPO-29659
Essentially we want to make sure each pipeline only has the access to whatever is necessary and nothing more, this means going from generalised Managed Identity used for all jobs across environments to environment specific ones.

### Testing done

TF Plans running...

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
